### PR TITLE
Add copy button to Github and Bitbucket workflow codes in setup docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vibinex-website",
-  "version": "0.1.9",
+  "version": "0.1.10",
   "private": false,
   "homepage": "https://vibinex.com",
   "description": "A plugin that works with GitHub, Bitbucket and GitLab to personalize and data-enrich their code review interfaces",

--- a/pages/docs/index.tsx
+++ b/pages/docs/index.tsx
@@ -8,6 +8,7 @@ import Footer from '../../components/Footer';
 import RudderContext from '../../components/RudderContext';
 import { getAndSetAnonymousIdFromLocalStorage } from '../../utils/rudderstack_initialize';
 import { getAuthUserId, getAuthUserName, login } from '../../utils/auth';
+import { MdContentCopy } from "react-icons/md";
 
 const verifySetup = [
 	"In your organization's repository list, you will see the Vibinex logo in front of the repositories that are correctly set up with Vibinex.",
@@ -61,8 +62,18 @@ const Docs = ({ bitbucket_auth_url }: { bitbucket_auth_url: string }) => {
 					subHeading: "Setup GitHub Action",
 					article: <>
 						Add this code in a file named &quot;repo-profiler.yml&quot; present on the following path - &quot;.github/workflows/repo-profiler.yml&quot; inside the repository.
-						<pre className="bg-gray-100 rounded-md p-3 ml-4 mb-4 font-mono whitespace-pre-wrap">
-							<code>
+						<pre className="bg-gray-100 rounded-md p-3 ml-4 mb-4 font-mono whitespace-pre-wrap relative">
+							<button
+								className="absolute top-0 right-0 border-none p-2"
+								onClick={() => {
+									const codeElement = document.getElementById("githubWorkflowCode");
+									const workflowText = codeElement?.textContent
+									navigator.clipboard.writeText(workflowText ?? "");
+								}}
+							>
+								<MdContentCopy />
+							</button>
+							<code id="githubWorkflowCode">
 								{`on:
   repository_dispatch:
     types: repo_profile_execution
@@ -112,8 +123,18 @@ jobs:
 					subHeading: "Code for setup",
 					article: <>
 						For each repository, add this Bitbucket Pipeline code in: `bitbucket-pipelines.yml`:
-						<pre className="bg-gray-100 ml-4 p-3 rounded-md font-mono whitespace-pre-wrap" >
-							<code>
+						<pre className="bg-gray-100 ml-4 p-3 rounded-md font-mono whitespace-pre-wrap relative" >
+							<button
+								className="absolute top-0 right-0 border-none p-2"
+								onClick={() => {
+									const codeElement = document.getElementById("bitbucketWorkflowCode");
+									const workflowText = codeElement?.textContent
+									navigator.clipboard.writeText(workflowText ?? "");
+								}}
+							>
+								<MdContentCopy />
+							</button>
+							<code id="bitbucketWorkflowCode">
 								{`image: atlassian/default-image:4
 pipelines:
   branches


### PR DESCRIPTION
## What does this PR do:

- Add a simple copy code button to the github and bitbucket workflow code blocks in the docs page. This makes quick setup easier and a bit more convenient, avoiding copying unintended parts of the page accidentally.

<img width="1130" alt="Screenshot 2023-11-18 at 11 44 56 PM" src="https://github.com/Alokit-Innovations/vibinex-server/assets/55079486/96a5fc93-7df9-4f4b-8c50-a64712b43794">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced copy functionality for code blocks in the documentation, allowing users to easily copy GitHub and Bitbucket workflow code to the clipboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->