### PR TITLE
created flow to generate topic_name for each client

### DIFF
--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -12,13 +12,13 @@ const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     }
     const topicName = await createTopicName(jsonBody.user_id, jsonBody.provider, jsonBody.org_name);
     if (!topicName){
-        console.error(`[pubsubHanlder] error in creating topic name`);
+        console.error(`[pubsubHandler] error in creating topic name`);
         res.status(500).json({"error": "topicName creation error"});
         return;
     }
     const topic = await createTopicNameInGcloud(jsonBody.user_id, topicName)
     if (!topic){
-        console.error(`[pubsubHanlder] error in creating topic in google cloud`);
+        console.error(`[pubsubHandler] error in creating topic in google cloud`);
         res.status(500).json({"error": "topic creation error in gcloud"});
         return;
     }

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -5,11 +5,11 @@ import { createTopicNameInGcloud } from '../../../utils/pubsub/pubsubClient';
 const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.info("[pubsubHandler] pub sub setup info in db...");
     const jsonBody = req.body;
-    // if (!jsonBody.user_id || !jsonBody.provider || !jsonBody.org_name) {
-    //     console.error("[pubsubHandler] Invalid request body, 'info' is missing or not an array");
-    //     res.status(400).json({"error": "Invalid request body"});
-    //     return;
-    // }
+    if (!jsonBody.user_id || !jsonBody.provider || !jsonBody.org_name) {
+        console.error("[pubsubHandler] Invalid request body, 'info' is missing or not an array");
+        res.status(400).json({"error": "Invalid request body"});
+        return;
+    }
     const topicName = await createTopicName(jsonBody.user_id, jsonBody.provider, jsonBody.org_name);
     console.log("[pubsubhandler] topicName", topicName);
     if (!topicName){

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -5,11 +5,11 @@ import { createTopicNameInGcloud } from '../../../utils/pubsub/pubsubClient';
 const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.info("[pubsubHandler] pub sub setup info in db...");
     const jsonBody = req.body;
-    if (!Array.isArray(jsonBody.info)) {
-        console.error("[pubsubHandler] Invalid request body, 'info' is missing or not an array");
-        res.status(400).json({"error": "Invalid request body"});
-        return;
-    }
+    // if (!jsonBody.user_id || !jsonBody.)) {
+    //     console.error("[pubsubHandler] Invalid request body, 'info' is missing or not an array");
+    //     res.status(400).json({"error": "Invalid request body"});
+    //     return;
+    // }
     const topicName = await createTopicName(jsonBody.user_id, jsonBody.provider, jsonBody.org_name);
     console.log("[pubsubhandler] topicName", topicName);
     if (!topicName){

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -6,12 +6,11 @@ const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.info("[pubsubHandler] pub sub setup info in db...");
     const jsonBody = req.body;
     if (!jsonBody.user_id || !jsonBody.provider || !jsonBody.org_name) {
-        console.error("[pubsubHandler] Invalid request body, 'info' is missing or not an array");
+        console.error("[pubsubHandler] Invalid request body");
         res.status(400).json({"error": "Invalid request body"});
         return;
     }
     const topicName = await createTopicName(jsonBody.user_id, jsonBody.provider, jsonBody.org_name);
-    console.log("[pubsubhandler] topicName", topicName);
     if (!topicName){
         console.error(`[pubsubHanlder] error in creating topic name`);
         res.status(500).json({"error": "topicName creation error"});
@@ -23,7 +22,6 @@ const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
         res.status(500).json({"error": "topic creation error in gcloud"});
         return;
     }
-    console.log("[pubsubHandler] gcloud topic: ", topic);
     await saveTopicNameInUsersTable(jsonBody.user_id, topicName);
     console.log("[pubsubHandler] topic name created successfully and saved in db: ", topicName);
     return res.status(200).json({"success": "topic name created and saved successfully"});

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -25,7 +25,7 @@ const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => { // 
     await saveTopicNameInUsersTable(jsonBody.user_id, topicName).catch((error) => {
         console.error("[pubsubHandler] Unable to save topic name in db, ", error);
     });
-    console.log("[pubsubHandler] topic name created successfully and saved in db: ", topicName);
+    console.info("[pubsubHandler] topic name created successfully and saved in db: ", topicName);
     return res.status(200).json({"success": "topic name created and saved successfully"});
 }
 

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -2,7 +2,7 @@ import { NextApiRequest, NextApiResponse } from 'next';
 import { saveTopicNameInUsersTable, createTopicName } from '../../../utils/db/relevance';
 import { createTopicNameInGcloud } from '../../../utils/pubsub/pubsubClient';
 
-const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => { // To be removed, only used for testing the functions
     console.info("[pubsubHandler] pub sub setup info in db...");
     const jsonBody = req.body;
     if (!jsonBody.user_id || !jsonBody.provider || !jsonBody.org_name) {
@@ -22,7 +22,9 @@ const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
         res.status(500).json({"error": "topic creation error in gcloud"});
         return;
     }
-    await saveTopicNameInUsersTable(jsonBody.user_id, topicName);
+    await saveTopicNameInUsersTable(jsonBody.user_id, topicName).catch((error) => {
+        console.error("[pubsubHandler] Unable to save topic name in db, ", error);
+    });
     console.log("[pubsubHandler] topic name created successfully and saved in db: ", topicName);
     return res.status(200).json({"success": "topic name created and saved successfully"});
 }

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -1,0 +1,32 @@
+import { NextApiRequest, NextApiResponse } from 'next';
+import { saveTopicNameInUsersTable, createTopicName } from '../../../utils/db/relevance';
+import { createTopicNameInGcloud } from '../../../utils/pubsub/pubsubClient';
+
+const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
+    console.info("[pubsubHandler] pub sub setup info in db...");
+    const jsonBody = req.body;
+    if (!Array.isArray(jsonBody.info)) {
+        console.error("[pubsubHandler] Invalid request body, 'info' is missing or not an array");
+        res.status(400).json({"error": "Invalid request body"});
+        return;
+    }
+    const topicName = await createTopicName(jsonBody.user_id, jsonBody.provider, jsonBody.org_name);
+    console.log("[pubsubhandler] topicName", topicName);
+    if (!topicName){
+        console.error(`[pubsubHanlder] error in creating topic name`);
+        res.status(500).json({"error": "topicName creation error"});
+        return;
+    }
+    const topic = await createTopicNameInGcloud(jsonBody.user_id, topicName)
+    if (!topic){
+        console.error(`[pubsubHanlder] error in creating topic in google cloud`);
+        res.status(500).json({"error": "topic creation error in gcloud"});
+        return;
+    }
+    console.log("[pubsubHandler] gcloud topic: ", topic);
+    await saveTopicNameInUsersTable(jsonBody.user_id, topicName);
+    console.log("[pubsubHandler] topic name created successfully and saved in db: ", topicName);
+    return res.status(200).json({"success": "topic name created and saved successfully"});
+}
+
+export default pubsubHandler;

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -5,12 +5,12 @@ import { createTopicNameInGcloud } from '../../../utils/pubsub/pubsubClient';
 const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => { // To be removed, only used for testing the functions
     console.info("[pubsubHandler] pub sub setup info in db...");
     const jsonBody = req.body;
-    if (!jsonBody.user_id || !jsonBody.provider || !jsonBody.org_name) {
+    if (!jsonBody.user_id) {
         console.error("[pubsubHandler] Invalid request body");
         res.status(400).json({"error": "Invalid request body"});
         return;
     }
-    const topicName = await createTopicName(jsonBody.user_id, jsonBody.provider, jsonBody.org_name);
+    const topicName = await createTopicName(jsonBody.user_id);
     if (!topicName){
         console.error(`[pubsubHandler] error in creating topic name`);
         res.status(500).json({"error": "topicName creation error"});

--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -5,7 +5,7 @@ import { createTopicNameInGcloud } from '../../../utils/pubsub/pubsubClient';
 const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => {
     console.info("[pubsubHandler] pub sub setup info in db...");
     const jsonBody = req.body;
-    // if (!jsonBody.user_id || !jsonBody.)) {
+    // if (!jsonBody.user_id || !jsonBody.provider || !jsonBody.org_name) {
     //     console.error("[pubsubHandler] Invalid request body, 'info' is missing or not an array");
     //     res.status(400).json({"error": "Invalid request body"});
     //     return;

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -162,7 +162,7 @@ export const saveTopicNameInUsersTable = async (userId: string, topicName: strin
 	const query = `
     Update users 
     set topic_name = $1 
-    WHERE id = $2'
+    WHERE id = $2
   `;
 	await conn.query(query, [topicName, userId]).catch(error => {
 		console.error(`[saveTopicNameInUsersTable] Unable to insert topic name in db`, { pg_query: query }, error);

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -163,9 +163,10 @@ export const createTopicName = async (user_id: string, provider: string, org_nam
 		return;
 	}
 	const provider_data = auth_info[provider];
-	const provider_id = provider_data[Object.keys(provider_data)[0]];
+	console.log("[createTopicName] provider_data: ", provider_data, Object.keys(provider));
+	const provider_id = provider_data[Object.keys(provider)[0]];
 
-	let topicName = `${org_name}-${userData.name}-${provider_id}`;
+	let topicName = `${org_name}-${userData.name?.replace(' ', '-')}-${provider_id}`;
 	return topicName;
 }
 

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -167,7 +167,7 @@ export const createTopicName = async (user_id: string, provider: string, org_nam
 		console.error(`[createTopicName] no auth_info present for the user with id: ${user_id} for provider: ${provider}`);
 		return;
 	}
-	const provider_id = provider_data[Object.keys(provider_data)[0]];
+	const provider_id = Object.keys(provider_data)[0];
 	if (!provider_id) {
 		console.error('[createTopicName] could not find provider_id');
 		return;

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -1,5 +1,6 @@
+import { error } from 'console';
 import conn from '.';
-import { getUserByAlias } from './users';
+import { getUserByAlias, getUserById, DbUser } from './users';
 
 export interface HunkInfo {
 	author: string,
@@ -142,5 +143,40 @@ export const saveTopicName = async (owner: string, provider: string, topicName: 
     `;
 	await conn.query(query).catch(err => {
 		console.error(`[saveTopicName] Unable to insert topic name in db`, { pg_query: query }, err)
+	});
+}
+
+export const createTopicName = async (user_id: string, provider: string, org_name: string) => {
+	console.log(`[createTopicName] creating topic name for user with id: ${user_id} and provider: ${provider} for org: ${org_name}`); 
+	let userData : DbUser | undefined;
+	userData = await getUserById(user_id).catch((error) => {
+		console.error('[createTopicName] Failed to get user data from db:', error);
+		return null;
+	});
+	if (!userData) {
+		console.error('[createTopicName]user data not found in db');
+		return;
+	}
+	const auth_info = userData.auth_info;
+	if (!auth_info){
+		console.error(` [createTopicName] auth_info is null for user with user_id: ${user_id}`);
+		return;
+	}
+	const provider_data = auth_info[provider];
+	const provider_id = provider_data[Object.keys(provider_data)[0]];
+
+	let topicName = `${org_name}-${userData.name}-${provider_id}`;
+	return topicName;
+}
+
+export const saveTopicNameInUsersTable = async (userId: string, topicName: string) => {
+	console.log(`[saveTopicNameInUsersTable] saving topic name: ${topicName} in users table in db for user_id:  ${userId}`); //TODO: To be removed
+	const query = `
+    Update users 
+    set topic_name = ${topicName} 
+    WHERE id = ${userId}'
+  `;
+	await conn.query(query).catch(error => {
+		console.error(`[saveTopicNameInUsersTable] Unable to insert topic name in db`, { pg_query: query }, error);
 	});
 }

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -1,6 +1,7 @@
 import { error } from 'console';
 import conn from '.';
 import { getUserByAlias, getUserById, DbUser } from './users';
+import { v4 as uuidv4 } from 'uuid';
 
 export interface HunkInfo {
 	author: string,
@@ -146,34 +147,13 @@ export const saveTopicName = async (owner: string, provider: string, topicName: 
 	});
 }
 
-export const createTopicName = async (user_id: string, provider: string, org_name: string) => {
-	console.log(`[createTopicName] creating topic name for user with id: ${user_id} and provider: ${provider} for org: ${org_name}`); 
-	let userData : DbUser | undefined;
-	userData = await getUserById(user_id).catch((error) => {
-		console.error('[createTopicName] Failed to get user data from db:', error);
-		return null;
-	});
-	if (!userData) {
-		console.error('[createTopicName]user data not found in db');
+export const createTopicName = async (user_id: string) => {
+	console.info(`[createTopicName] creating topic name for user with id: ${user_id}`); 
+	let topicName = uuidv4();
+	if (!topicName) {
+		console.error(`[createTopicName] could not create topic name`);
 		return null;
 	}
-	const auth_info = userData.auth_info;
-	if (!auth_info){
-		console.error(` [createTopicName] auth_info is null for user with user_id: ${user_id}`);
-		return null;
-	}
-	const provider_data = auth_info[provider];
-	if (!provider_data) {
-		console.error(`[createTopicName] no auth_info present for the user with id: ${user_id} for provider: ${provider}`);
-		return null;
-	}
-	const provider_id = Object.keys(provider_data)[0];
-	if (!provider_id) {
-		console.error('[createTopicName] could not find provider_id');
-		return null;
-	}
-
-	let topicName = `${org_name}-${userData.name?.replace(' ', '-')}-${provider_id}`;
 	return topicName;
 }
 

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -171,7 +171,6 @@ export const createTopicName = async (user_id: string, provider: string, org_nam
 	if (!provider_id) {
 		console.error('[createTopicName] could not find provider_id');
 		return;
-
 	}
 
 	let topicName = `${org_name}-${userData.name?.replace(' ', '-')}-${provider_id}`;

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -164,7 +164,7 @@ export const createTopicName = async (user_id: string, provider: string, org_nam
 	}
 	const provider_data = auth_info[provider];
 	console.log("[createTopicName] provider_data: ", provider_data, Object.keys(provider));
-	const provider_id = provider_data[Object.keys(provider)[0]];
+	const provider_id = provider_data[Object.keys(provider_data)[0]];
 
 	let topicName = `${org_name}-${userData.name?.replace(' ', '-')}-${provider_id}`;
 	return topicName;

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -163,8 +163,16 @@ export const createTopicName = async (user_id: string, provider: string, org_nam
 		return;
 	}
 	const provider_data = auth_info[provider];
-	console.log("[createTopicName] provider_data: ", provider_data, Object.keys(provider));
+	if (!provider_data) {
+		console.error(`[createTopicName] no auth_info present for the user with id: ${user_id} for provider: ${provider}`);
+		return;
+	}
 	const provider_id = provider_data[Object.keys(provider_data)[0]];
+	if (!provider_id) {
+		console.error('[createTopicName] could not find provider_id');
+		return;
+
+	}
 
 	let topicName = `${org_name}-${userData.name?.replace(' ', '-')}-${provider_id}`;
 	return topicName;

--- a/utils/db/relevance.ts
+++ b/utils/db/relevance.ts
@@ -155,22 +155,22 @@ export const createTopicName = async (user_id: string, provider: string, org_nam
 	});
 	if (!userData) {
 		console.error('[createTopicName]user data not found in db');
-		return;
+		return null;
 	}
 	const auth_info = userData.auth_info;
 	if (!auth_info){
 		console.error(` [createTopicName] auth_info is null for user with user_id: ${user_id}`);
-		return;
+		return null;
 	}
 	const provider_data = auth_info[provider];
 	if (!provider_data) {
 		console.error(`[createTopicName] no auth_info present for the user with id: ${user_id} for provider: ${provider}`);
-		return;
+		return null;
 	}
 	const provider_id = Object.keys(provider_data)[0];
 	if (!provider_id) {
 		console.error('[createTopicName] could not find provider_id');
-		return;
+		return null;
 	}
 
 	let topicName = `${org_name}-${userData.name?.replace(' ', '-')}-${provider_id}`;
@@ -181,10 +181,10 @@ export const saveTopicNameInUsersTable = async (userId: string, topicName: strin
 	console.log(`[saveTopicNameInUsersTable] saving topic name: ${topicName} in users table in db for user_id:  ${userId}`); //TODO: To be removed
 	const query = `
     Update users 
-    set topic_name = ${topicName} 
-    WHERE id = ${userId}'
+    set topic_name = $1 
+    WHERE id = $2'
   `;
-	await conn.query(query).catch(error => {
+	await conn.query(query, [topicName, userId]).catch(error => {
 		console.error(`[saveTopicNameInUsersTable] Unable to insert topic name in db`, { pg_query: query }, error);
 	});
 }

--- a/utils/db/users.ts
+++ b/utils/db/users.ts
@@ -40,7 +40,7 @@ export const getUserById = async (userId: string) => { //This function is not us
 	const user_search_by_id_result = await conn.query(user_search_by_id_q, [userId]).catch(err => {
 		console.error(`[getUserById] Could not get the user for user id: ${userId}`, { pg_query: user_search_by_id_q }, err);
 		throw new Error("Error in running the query on the database", err);
-	});;
+	});
 	if (user_search_by_id_result.rows.length === 0) {
 		throw new Error('No user found');
 	}

--- a/utils/db/users.ts
+++ b/utils/db/users.ts
@@ -36,16 +36,16 @@ export const getUserByProvider = async (provider: string, providerAccountId: str
 export const getUserById = async (userId: string) => {
 	const user_search_by_id_q = `SELECT *
 	FROM users
-	WHERE id = '${userId}'`
-	const user_search_by_id_result = await conn.query(user_search_by_id_q).catch(err => {
+	WHERE id = $1`
+	const user_search_by_id_result = await conn.query(user_search_by_id_q, [userId]).catch(err => {
 		console.error(`[getUserById] Could not get the user for user id: ${userId}`, { pg_query: user_search_by_id_q }, err);
 		throw new Error("Error in running the query on the database", err);
 	});;
 	if (user_search_by_id_result.rows.length === 0) {
-		throw new Error('No topic found');
+		throw new Error('No user found');
 	}
 	if (user_search_by_id_result.rowCount > 1) {
-		console.warn("[getUser] Multiple users exist with same id", { userId });
+		console.warn("[getUserById] Multiple users exist with same id", { userId });
 	}
 	
 	return user_search_by_id_result.rows[0];

--- a/utils/db/users.ts
+++ b/utils/db/users.ts
@@ -13,6 +13,7 @@ export interface DbUser {
 	code_url?: Array<string>,
 	social_url?: Array<string>,
 	repos?: Array<number>,
+	topic_name?: string,
 }
 
 export const getUserByProvider = async (provider: string, providerAccountId: string) => {
@@ -30,6 +31,24 @@ export const getUserByProvider = async (provider: string, providerAccountId: str
 		return user_auth_search_result.rows[0];
 	}
 	return undefined;
+}
+
+export const getUserById = async (userId: string) => {
+	const user_search_by_id_q = `SELECT *
+	FROM users
+	WHERE id = '${userId}'`
+	const user_search_by_id_result = await conn.query(user_search_by_id_q).catch(err => {
+		console.error(`[getUserById] Could not get the user for user id: ${userId}`, { pg_query: user_search_by_id_q }, err);
+		throw new Error("Error in running the query on the database", err);
+	});;
+	if (user_search_by_id_result.rows.length === 0) {
+		throw new Error('No topic found');
+	}
+	if (user_search_by_id_result.rowCount > 1) {
+		console.warn("[getUser] Multiple users exist with same id", { userId });
+	}
+	
+	return user_search_by_id_result.rows[0];
 }
 
 export const getUserByAlias = async (alias_email: string): Promise<DbUser[] | undefined> => {

--- a/utils/db/users.ts
+++ b/utils/db/users.ts
@@ -33,7 +33,7 @@ export const getUserByProvider = async (provider: string, providerAccountId: str
 	return undefined;
 }
 
-export const getUserById = async (userId: string) => {
+export const getUserById = async (userId: string) => { //This function is not used anywhere currently in the code but letting it be, since we might use it in near future.
 	const user_search_by_id_q = `SELECT *
 	FROM users
 	WHERE id = $1`

--- a/utils/pubsub/pubsubClient.ts
+++ b/utils/pubsub/pubsubClient.ts
@@ -16,3 +16,13 @@ export function publishMessage(topicName: string, data: PubSubMessage, msgType: 
   return topic.publishMessage(message);
 
 }
+
+export async function createTopicNameInGcloud(userId: string, topicName: string) {  
+  try {
+    const [topic] = await pubsub.createTopic(topicName);
+    console.log(`[createTopicNameInGcloud] Topic ${topic.name} created.`);
+    return topic;
+} catch (error) {
+    console.error('[createTopicNameInGcloud] Failed to create topic name in gcloud:', error);
+    return null;
+}}


### PR DESCRIPTION
- [x] Created a function to generate topic_name for each user in the form `org_name-user_name-user_provider_id` .
- [x] Save topic in db in `users` table against users only.
- [x] Create the same topic name in gcloud as well

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new API route for handling topic creation and management in the app.
  - Users can now have a topic name associated with their profile for better content organization.

- **Enhancements**
  - Improved error handling and logging for topic name creation and database operations.

- **Documentation**
  - Updated API documentation to reflect new topic management capabilities.

- **Bug Fixes**
  - Fixed potential issues with user retrieval by implementing additional error checks and logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->