### PR TITLE
Redirect to docs instead of u.tsx after app installation

### DIFF
--- a/pages/api/bitbucket/callbacks/install.ts
+++ b/pages/api/bitbucket/callbacks/install.ts
@@ -33,9 +33,9 @@ const installHandler = async (req: NextApiRequest, res: NextApiResponse) => {
 
 	res.write(
 		`<script>
-			location.href="/u"
+			location.href="/docs"
 		</script>\
-		If you are not automatically redirected, <a href="/u">click here</a>`
+		If you are not automatically redirected, <a href="/docs">click here</a>`
 	);
 	res.end();
 }

--- a/pages/api/github/callbacks/install.ts
+++ b/pages/api/github/callbacks/install.ts
@@ -33,9 +33,9 @@ const installHandler = async (req: NextApiRequest, res: NextApiResponse) => {
 
 	res.write(
 		`<script>
-			location.href="/u"
+			location.href="/docs"
 		</script>\
-		If you are not automatically redirected, <a href="/u">click here</a>`
+		If you are not automatically redirected, <a href="/docs">click here</a>`
 	);
 	res.end();
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Updated the installation callback redirect for Bitbucket and GitHub integrations to point to "/docs" instead of "/u" with an improved message for clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->