### PR TITLE
TrustUs view changed in Landing page

### DIFF
--- a/views/TrustUs.tsx
+++ b/views/TrustUs.tsx
@@ -1,25 +1,29 @@
 import React from 'react'
 import { BiCodeBlock, BiWindowOpen } from 'react-icons/bi'
 import { BsShieldLock } from 'react-icons/bs'
+import { IconContext } from 'react-icons'
+
 const data = [
-	{ icon: <BiCodeBlock size={40} />, heading: 'Easy to setup', content: 'Get started with GitHub Actions/Bitbucket Pipes in less than 10 minutes' },
-	{ icon: <BsShieldLock size={40} />, heading: 'Data privacy at peak', content: 'Your code never leaves the machines you control' },
-	{ icon: <BiWindowOpen size={40} />, heading: 'Free & open source', content: '100% transparency means 100% trust' },
+	{ icon: <BiCodeBlock />, heading: 'Zero onboarding', content: 'Vibinex brings insights to your GitHub or Bitbucket code-review page' },
+	{ icon: <BsShieldLock />, heading: 'Data privacy', content: 'Your code and other sensitive data never leaves your infrastructure' },
+	{ icon: <BiWindowOpen />, heading: 'Open source', content: '100% transparency means 100% trust' },
 ]
 
-const WhyUs = () => {
+const TrustUs = () => {
 	return (
 		<div id='trust' className='w-full text-center py-12 bg-secondary-main'>
 			<h2 className='font-bold text-[2rem]'>Stay calm and get <span className='text-[2rem] text-primary-main font-bold'>Vibinex</span></h2>
-			<div className='w-[100%] mt-3 p-4'>
+			<div className='sm:w-2/3 w-[90%] mt-3 p-4 flex flex-col sm:flex-row sm:justify-center items-center gap-8 mx-auto'>
 				{data.map((item) => (
-					<div key={item.heading} className="flex sm:p-5 p-3 rounded-lg border-2 mt-7 sm:w-[50%]  w-[90%] m-auto border-primary-main">
-						<div className=''>
-							{item.icon}
+					<div key={item.heading} className="flex flex-row sm:flex-col sm:p-5 p-3 rounded-lg border-2 sm:mt-7 m-auto border-primary-main w-full sm:w-1/3 sm:h-96 sm:gap-4">
+						<div className='w-10 sm:w-3/4 sm:mx-auto'>
+							<IconContext.Provider value={{ size: '100%', className: 'm-auto' }}>
+								{item.icon}
+							</IconContext.Provider>
 						</div>
-						<div className='mx-auto'>
+						<div className='mx-auto w-full'>
 							<h2 className='font-semibold text-[1.5rem]'>{item.heading}</h2>
-							<p className='w-[80%] m-auto'>{item.content}</p>
+							<p className='w-[80%] sm:w-full m-auto'>{item.content}</p>
 						</div>
 					</div>
 				))}
@@ -27,4 +31,4 @@ const WhyUs = () => {
 		</div>
 	)
 }
-export default WhyUs
+export default TrustUs

--- a/views/TrustUs.tsx
+++ b/views/TrustUs.tsx
@@ -1,29 +1,30 @@
 import React from 'react'
-import { BiCodeBlock, BiWindowOpen } from 'react-icons/bi'
-import { BsShieldLock } from 'react-icons/bs'
+import { BiCodeBlock } from 'react-icons/bi'
 import { IconContext } from 'react-icons'
+import { IoSpeedometerOutline } from "react-icons/io5";
+import { RiGitRepositoryPrivateLine } from "react-icons/ri";
 
 const data = [
-	{ icon: <BiCodeBlock />, heading: 'Zero onboarding', content: 'Vibinex brings insights to your GitHub or Bitbucket code-review page' },
-	{ icon: <BsShieldLock />, heading: 'Data privacy', content: 'Your code and other sensitive data never leaves your infrastructure' },
-	{ icon: <BiWindowOpen />, heading: 'Open source', content: '100% transparency means 100% trust' },
+	{ icon: <IoSpeedometerOutline />, heading: 'Zero onboarding', content: 'Vibinex brings insights to your GitHub or Bitbucket code-review page' },
+	{ icon: <RiGitRepositoryPrivateLine />, heading: 'Data privacy', content: 'Your code and other sensitive data never leaves your infrastructure' },
+	{ icon: <BiCodeBlock />, heading: 'Open source', content: '100% transparency means 100% trust' },
 ]
 
 const TrustUs = () => {
 	return (
 		<div id='trust' className='w-full text-center py-12 bg-secondary-main'>
 			<h2 className='font-bold text-[2rem]'>Stay calm and get <span className='text-[2rem] text-primary-main font-bold'>Vibinex</span></h2>
-			<div className='sm:w-2/3 w-[90%] mt-3 p-4 flex flex-col sm:flex-row sm:justify-center items-center gap-8 mx-auto'>
+			<div className='md:w-2/3 w-[90%] mt-3 p-4 flex flex-col md:flex-row md:justify-center items-center gap-8 mx-auto'>
 				{data.map((item) => (
-					<div key={item.heading} className="flex flex-row sm:flex-col sm:p-5 p-3 rounded-lg border-2 sm:mt-7 m-auto border-primary-main w-full sm:w-1/3 sm:h-96 sm:gap-4">
-						<div className='w-10 sm:w-3/4 sm:mx-auto'>
+					<div key={item.heading} className="flex flex-row md:flex-col md:p-5 p-3 rounded-lg border-2 md:mt-7 m-auto border-primary-main w-full md:w-1/3 md:h-96 md:gap-4">
+						<div className='w-10 md:w-3/4 xl:w-1/2 md:mx-auto'>
 							<IconContext.Provider value={{ size: '100%', className: 'm-auto' }}>
 								{item.icon}
 							</IconContext.Provider>
 						</div>
 						<div className='mx-auto w-full'>
 							<h2 className='font-semibold text-[1.5rem]'>{item.heading}</h2>
-							<p className='w-[80%] sm:w-full m-auto'>{item.content}</p>
+							<p className='w-[80%] md:w-full md:mt-2 m-auto xl:mt-4'>{item.content}</p>
 						</div>
 					</div>
 				))}


### PR DESCRIPTION
Changes in the trust-us view:
1. The items are now arranged as verticle columns instead of horizontal ones for wider screens. 
2. Fixed the name of the component function (`WhyUs` --> `TrustUs`)
3. Changed the icons used in each item.