### PR TITLE
fixed return response in `api/dpu/pubsub` endpoint

### DIFF
--- a/pages/api/dpu/pubsub.ts
+++ b/pages/api/dpu/pubsub.ts
@@ -41,34 +41,7 @@ const pubsubHandler = async (req: NextApiRequest, res: NextApiResponse) => { // 
         })
     }
     console.info("[pubsubHandler] topic name created successfully and saved in db: ", topicName);
-
-    //check if already a build exists in users table for the user, if yes? check status else continue
-    
-    const buildStatus : CloudBuildStatus = await triggerBuildUsingGcloudApi(jsonBody.user_id, topicName);
-    console.info("[pubsubHandler] build status: ", buildStatus);
-    if (!buildStatus.success) {
-        console.error('[pubsubHandler] Error triggering build:', buildStatus.message);
-        return res.status(500).json({ "error": buildStatus.message, success: false });
-    }
-    const projectId: string | undefined = process.env.PROJECT_ID;
-    const location: string | undefined = process.env.CLOUD_BUILD_LOCATION;
-    if (!projectId || !location) {
-        console.error('[pubsubHandler] Environment variables for projectId and location must be set');
-        res.status(500).json({"error": "env variables must be set", success: false});
-        return;
-    }
-    const buildId = buildStatus.buildDetails?.id;
-    if (!buildId) {
-        console.error('[pubsubHandler] No build ID found in buildDetails');
-        return res.status(500).json({ error: 'No build ID found', success: false });
-    }
-    const finalBuildStatus = await pollBuildStatus(projectId, location, buildId);
-    if (finalBuildStatus === 'SUCCESS') {
-        return res.status(200).json({ message: 'Build completed successfully', success: true });
-    } else {
-        console.error(`[pubsubHandler] Build failed with status: ${finalBuildStatus}`);
-        return res.status(500).json({ error: `Build failed with status: ${finalBuildStatus}`, success: false });
-    }
+    return res.status(200).json({"install_id": topicName});
 }
 
 export default pubsubHandler;


### PR DESCRIPTION
- I believe this was a mistake, in case of self-hosting we use `/api/dpu/pubsub` endpoint and it should only return created topic_name as install_id and should not trigger any build right?! So reverted the changes and made the api response as expected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the `pubsubHandler` function to directly return the "install_id" in a JSON response, removing previous build-related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->