### PR TITLE
Major fix: GitHub App link fix

### DIFF
--- a/components/setup/TriggerContent.tsx
+++ b/components/setup/TriggerContent.tsx
@@ -14,7 +14,7 @@ const TriggerContent: React.FC<TriggerContentProps> = ({ selectedProvider, bitbu
                     <Button
                         id='github-app-install'
                         variant="contained"
-                        href="https://github.com/apps/vibinex-code-review"
+                        href="https://github.com/apps/vibinex-dpu"
                         target='_blank'
                     >
                         Install Github App


### PR DESCRIPTION
The current link to pointing to the old GitHub App (which has a callback URL set to the `devprofiler-cloudrun` server.
Fixed it by changing it to the `vibinex-dpu` GitHub App.