### PR TITLE
fixed reuqest body parameter in log, `owner` instead of `org` 

### DIFF
--- a/pages/api/extension/setup.ts
+++ b/pages/api/extension/setup.ts
@@ -10,7 +10,7 @@ export default async function setupRepos(req: NextApiRequest, res: NextApiRespon
 		return;
 	}
 	// For normal requests
-	console.info("[extension/setup] Getting setup repos info for ", req.body.org);
+	console.info("[extension/setup] Getting setup repos info for ", req.body.owner);
 	
 	if (req.method !== 'POST') {
 		return res.status(405).json({ error: 'Method Not Allowed', message: 'Only POST requests are allowed' });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated a log message parameter in the extension setup process for clarity and accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->