### PR TITLE
UI improvements: empty aliases form

### DIFF
--- a/components/GitAliasForm.tsx
+++ b/components/GitAliasForm.tsx
@@ -12,7 +12,7 @@ const GitAliasForm: React.FC<{ expanded: boolean }> = ({ expanded }) => {
 	useEffect(() => {
 		const fetchData = async () => {
 			try {
-				const response = await axios.get(`/api/alias`);
+				const response = await axios.get(`/api/alias`, { params: { expanded } });
 				if (!response.data?.aliasProviderMap) {
 					throw new Error('Failed to fetch Git email aliases');
 				}
@@ -70,13 +70,10 @@ const GitAliasForm: React.FC<{ expanded: boolean }> = ({ expanded }) => {
 		<form onSubmit={handleSubmit}>
 			{loading ? (
 				<div>Loading...</div>
-			) : gitAliasMap ? (
+			) : (gitAliasMap?.providerMaps && gitAliasMap.providerMaps.length > 0) ? (
 				<>
-					{!expanded && (
-						<div className="bg-blue-200 text-blue-800 p-4 rounded-md mb-4 text-center">
-							<p className="font-bold">Please enter Github/Bitbucket usernames and click Submit:</p>
-						</div>
-					)}
+					<h3 className="font-bold mb-4">Please enter Github/Bitbucket usernames and click Submit:</h3>
+
 					{/* Header */}
 					<div className="grid grid-cols-3 border-b text-blue-800">
 						<div className="p-4">
@@ -91,49 +88,46 @@ const GitAliasForm: React.FC<{ expanded: boolean }> = ({ expanded }) => {
 					</div>
 
 					{/* Rows */}
-					{gitAliasMap.providerMaps.map((providerMap: AliasMap) => {
-						const hasHandles = providerMap.handleMaps && providerMap.handleMaps.some(handleMap => handleMap.handles.length > 0);
-						return expanded || !hasHandles ? (
-							<div key={providerMap.alias} className="grid grid-cols-3 border-b border-gray-300">
-								{/* Alias column */}
-								<div className="p-4">
-									<div>{providerMap.alias}</div>
-								</div>
-
-								{/* github column */}
-								<div className="p-4">
-									<div>
-										<input
-											type="text"
-											value={handleInputValues[providerMap.alias]?.github || ''}
-											onChange={(e) => handleInputChange(providerMap.alias, 'github', e.target.value)}
-											className="mb-2 w-full"
-										/>
-									</div>
-									{/* Display additional handles beneath the input field if available */}
-									{providerMap.handleMaps?.find(handleMap => handleMap.provider === 'github')?.handles.map((handle: string) => (
-										<Chip key={handle} name={handle} avatar={"/github-dark.svg"} disabled={false} />
-									))}
-								</div>
-
-								{/* bitbucket column */}
-								<div className="p-4">
-									<div>
-										<input
-											type="text"
-											value={handleInputValues[providerMap.alias]?.bitbucket || ''}
-											onChange={(e) => handleInputChange(providerMap.alias, 'bitbucket', e.target.value)}
-											className="mb-2 w-full"
-										/>
-									</div>
-									{/* Display additional handles beneath the input field if available */}
-									{providerMap.handleMaps?.find(handleMap => handleMap.provider === 'bitbucket')?.handles.map((handle: string) => (
-										<Chip key={handle} name={handle} avatar={"/bitbucket-dark.svg"} disabled={false} />
-									))}
-								</div>
+					{gitAliasMap.providerMaps.map((providerMap: AliasMap) => (
+						<div key={providerMap.alias} className="grid grid-cols-3 border-b border-gray-300">
+							{/* Alias column */}
+							<div className="p-4">
+								<div>{providerMap.alias}</div>
 							</div>
-						) : null;
-					})}
+
+							{/* github column */}
+							<div className="p-4">
+								<div>
+									<input
+										type="text"
+										value={handleInputValues[providerMap.alias]?.github || ''}
+										onChange={(e) => handleInputChange(providerMap.alias, 'github', e.target.value)}
+										className="mb-2 w-full"
+									/>
+								</div>
+								{/* Display additional handles beneath the input field if available */}
+								{providerMap.handleMaps?.find(handleMap => handleMap.provider === 'github')?.handles.map((handle: string) => (
+									<Chip key={handle} name={handle} avatar={"/github-dark.svg"} disabled={false} />
+								))}
+							</div>
+
+							{/* bitbucket column */}
+							<div className="p-4">
+								<div>
+									<input
+										type="text"
+										value={handleInputValues[providerMap.alias]?.bitbucket || ''}
+										onChange={(e) => handleInputChange(providerMap.alias, 'bitbucket', e.target.value)}
+										className="mb-2 w-full"
+									/>
+								</div>
+								{/* Display additional handles beneath the input field if available */}
+								{providerMap.handleMaps?.find(handleMap => handleMap.provider === 'bitbucket')?.handles.map((handle: string) => (
+									<Chip key={handle} name={handle} avatar={"/bitbucket-dark.svg"} disabled={false} />
+								))}
+							</div>
+						</div>
+					))}
 					{/* Buttons */}
 					<div className="mt-4 flex gap-2">
 						<Button variant="contained" type="submit" className={`${expanded ? 'w-full block mb-4' : ''}`}>Submit</Button>
@@ -142,9 +136,13 @@ const GitAliasForm: React.FC<{ expanded: boolean }> = ({ expanded }) => {
 						)}
 					</div>
 				</>
-			) : (
-				<div>No data available</div>
-			)}
+			) : expanded ? (
+				<div className="h-screen-1/2 text-primary-text flex flex-col items-center justify-center" >
+					<p className="font-bold text-lg">No aliases found</p>
+					<p>Please setup a repository from this account to view aliases</p>
+				</div>
+			) : null
+			}
 		</form>
 	);
 };

--- a/pages/api/alias.ts
+++ b/pages/api/alias.ts
@@ -21,7 +21,7 @@ const aliasHandler = async (req: NextApiRequest, res: NextApiResponse) => {
             res.status(400).json({ error: "Invalid parameters in query: `expanded` must be true or false." });
             return;
         }
-        const expanded: boolean = JSON.parse(String(query?.expanded) || "false");
+        const expanded: boolean = query?.expanded === "true";
         await getGitEmailAliases(userId, expanded)
         .then((aliasProviderMap) => {
             res.status(200).json({ aliasProviderMap });

--- a/pages/api/alias.ts
+++ b/pages/api/alias.ts
@@ -1,11 +1,11 @@
 import { NextApiRequest, NextApiResponse } from "next";
-import { getGitEmailAliasesFromDB, saveGitAliasMapToDB } from "../../utils/db/aliases";
+import { getGitAliasesWithHandlesFromDB, saveGitAliasMapToDB } from "../../utils/db/aliases";
 import { AliasProviderMap } from "../../types/AliasMap";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "./auth/[...nextauth]";
 
 const aliasHandler = async (req: NextApiRequest, res: NextApiResponse) => {
-    const { method, body } = req;
+    const { method, query, body } = req;
     const session = await getServerSession(req, res, authOptions);
 	if (!session) {
 		return res.status(401).json({ message: 'Unauthenticated' });
@@ -16,7 +16,13 @@ const aliasHandler = async (req: NextApiRequest, res: NextApiResponse) => {
             res.status(500).json({error: "No user id in session"});
             return;
         }
-        await getGitEmailAliases(userId)
+        // check if query object has the expanded element and if it does, then check if it is true or false
+        if (query?.expanded && query?.expanded !== "true" && query?.expanded !== "false") {
+            res.status(400).json({ error: "Invalid parameters in query: `expanded` must be true or false." });
+            return;
+        }
+        const expanded: boolean = JSON.parse(String(query?.expanded) || "false");
+        await getGitEmailAliases(userId, expanded)
         .then((aliasProviderMap) => {
             res.status(200).json({ aliasProviderMap });
         }).catch((error) => {
@@ -36,14 +42,21 @@ const aliasHandler = async (req: NextApiRequest, res: NextApiResponse) => {
 }
 
 
-const getGitEmailAliases = async (userId: string): Promise<AliasProviderMap> => {
+const getGitEmailAliases = async (userId: string, expanded?: boolean): Promise<AliasProviderMap> => {
     // Validate that userId is provided
     if (!userId) {
         throw new Error("User ID is required to fetch Git email aliases.");
     }
 
     // Call the database function to get Git email aliases
-    return await getGitEmailAliasesFromDB(userId);
+    const allGitAliasMap = await getGitAliasesWithHandlesFromDB(userId);
+    if (expanded) return allGitAliasMap;
+    return {
+        providerMaps: allGitAliasMap.providerMaps.filter((providerMap) => {
+            const hasHandles = providerMap.handleMaps && providerMap.handleMaps.some(handleMap => handleMap.handles.length > 0);
+            return !hasHandles;
+        })
+    }
 }
 
 const saveGitAliasMap = async (aliasProviderMap: AliasProviderMap): Promise<void> => {

--- a/utils/db/aliases.ts
+++ b/utils/db/aliases.ts
@@ -49,7 +49,7 @@ export const getUserAliasesFromRepo = async (repoName: string, repoOwner: string
     return aliases;
 };
 
-export const getGitEmailAliasesFromDB = async (userId: string): Promise<AliasProviderMap> =>  {
+export const getGitAliasesWithHandlesFromDB = async (userId: string): Promise<AliasProviderMap> => {
     const query = `
     SELECT 
         git_alias,


### PR DESCRIPTION
When the user does not have any aliases to edit, our current user interface looks very messy.
This PR fixes that.

It completely removes the component if the `expanded` prop is `false`.

And it looks like this if the `expanded` prop is `true` (screenshot taken from the 'settings' page):
![image](https://github.com/Alokit-Innovations/vibinex-server/assets/7858932/158cebc6-9d1c-4c0d-a111-430176ce9c9d)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Added support for expanded Git alias information based on provider maps.
- **Enhancements**
	- Improved user interface to display Github and Bitbucket handles more intuitively.
	- Enhanced feedback for situations where no aliases are found.
- **Refactor**
	- Updated alias fetching functionality to include an `expanded` query option for more detailed information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->