### PR TITLE
Setup repos fix

### DIFF
--- a/pages/api/extension/setup.ts
+++ b/pages/api/extension/setup.ts
@@ -11,7 +11,7 @@ export default async function setupRepos(req: NextApiRequest, res: NextApiRespon
 	}
 	// For normal requests
 	console.info("[extension/setup] Getting setup repos info for ", req.body.owner);
-	
+
 	if (req.method !== 'POST') {
 		return res.status(405).json({ error: 'Method Not Allowed', message: 'Only POST requests are allowed' });
 	}
@@ -20,11 +20,11 @@ export default async function setupRepos(req: NextApiRequest, res: NextApiRespon
 		return res.status(400).json({ error: 'Bad Request', message: 'Both the arguments owner, and provider are required in the request body' });
 	}
 	getSetupReposFromDbForOwner(owner, provider)
-	.then((repos: string[]) => {
-		res.status(200).json({ repos: repos });
-	})
-	.catch((error: Error) => {
-		console.error('[extension/setup] Error fetching repositories from database for org: ' + owner + ' and provider: ' + provider, error);
-		res.status(500).json({ error: 'Internal Server Error', message: 'An error occurred while fetching repositories from the database' });
-	});
+		.then((repos: string[]) => {
+			res.status(200).json({ repos: repos });
+		})
+		.catch((error: Error) => {
+			console.error('[extension/setup] Error fetching repositories from database for org: ' + owner + ' and provider: ' + provider, error);
+			res.status(500).json({ error: 'Internal Server Error', message: 'An error occurred while fetching repositories from the database' });
+		});
 }

--- a/utils/db/setup.ts
+++ b/utils/db/setup.ts
@@ -3,8 +3,9 @@ import conn from '.';
 export const getSetupReposFromDbForOwner = async (owner: string, provider: string): Promise<string[]> => {
 	console.log(`[getSetupReposFromDbForOwner] Getting setup repos from db for owner ${owner} and provider ${provider}`);
 	const query = `SELECT repos.repo_name
-        FROM repos
-        WHERE repos.repo_owner = $1 AND repos.repo_provider = $2;
+		FROM repos
+		WHERE repos.repo_owner = $1 AND repos.repo_provider = $2
+			AND  install_id IS NOT NULL AND install_id != '{}';
     `;
 	const result = await conn.query(query, [owner, provider]).catch(err => {
 		console.error(`[getSetupReposFromDbForOwner] Could not get the github repos for owner ${owner} and provider ${provider}`, { pg_query: query }, err);


### PR DESCRIPTION
This PR assumes that a repository is active as long as it contains any `install_id`. We will have to improve this in the future. There are various repositories in our database which have an `install_id` but are clearly inactive.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved code readability in the repository setup process.
- **Bug Fixes**
	- Enhanced database query logic to exclude records with undefined or empty `install_id`, ensuring more accurate data retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->