### PR TITLE
Bugfix/repo config

### DIFF
--- a/utils/db/repos.ts
+++ b/utils/db/repos.ts
@@ -153,7 +153,7 @@ export const getRepoConfigByUserAndRepo = async (provider: string, repoName: str
 		r.repo_provider = '${provider}')
     `;
     const result = await conn.query(query).catch(err => {
-		console.error(`[getRepoConfig] Could not get repo config for: ${userId}, ${repoName}`,
+		console.error(`[getRepoConfigByUserAndRepo] Could not get repo config for: ${userId}, ${repoName}`,
             { pg_query: query }, err);
 		throw new Error("Error in running the query on the database", err);
 	});
@@ -166,6 +166,7 @@ export const getRepoConfigByUserAndRepo = async (provider: string, repoName: str
 	const userRows = result.rows.filter((rowVal) => rowVal.userid === userId);
 	if (userRows.length === 0) {
 		// return some default
+		console.error(`[getRepoConfigByUserAndRepo] repo config not found for user: ${userId}. Sending defualts..`);
 		return {auto_assign: false, comment: false};
 	}
 	return userRows[0].config;

--- a/utils/db/repos.ts
+++ b/utils/db/repos.ts
@@ -163,7 +163,7 @@ export const getRepoConfigByUserAndRepo = async (provider: string, repoName: str
 	if (result.rows.length === 1) {
 		return result.rows[0].config;
 	}
-	const userRows = result.rows.filter((rowVal) => rowVal.userId === userId);
+	const userRows = result.rows.filter((rowVal) => rowVal.userid === userId);
 	if (userRows.length === 0) {
 		// return some default
 		return {auto_assign: false, comment: false};

--- a/utils/db/repos.ts
+++ b/utils/db/repos.ts
@@ -145,7 +145,7 @@ export const getRepoConfigByUserAndRepo = async (provider: string, repoName: str
         'auto_assign', rc.auto_assign,
         'comment', rc.comment_setting
     ) AS config,
-	rc.user_id AS userId
+	rc.user_id AS user_id
     FROM repo_config rc
     WHERE repo_id = (SELECT r.id FROM repos r 
 		WHERE r.repo_name = '${repoName}' AND
@@ -163,7 +163,7 @@ export const getRepoConfigByUserAndRepo = async (provider: string, repoName: str
 	if (result.rows.length === 1) {
 		return result.rows[0].config;
 	}
-	const userRows = result.rows.filter((rowVal) => rowVal.userid === userId);
+	const userRows = result.rows.filter((rowVal) => rowVal.user_id === userId);
 	if (userRows.length === 0) {
 		// return some default
 		console.error(`[getRepoConfigByUserAndRepo] repo config not found for user: ${userId}. Sending defualts..`);


### PR DESCRIPTION
- [x] Build running
- [x] Manually tested

Query instructs to return column as `userId` but somewhere, somehow it gets converted to `userid`. This fix takes that into account.

Successful trigger comment - 
![image](https://github.com/Alokit-Innovations/vibinex-server/assets/3296555/85be1bf4-2657-407e-8579-d449bac905d6)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **Refactor**
	- Improved error handling, logging, and filtering by `userId` in repository configuration retrieval.
	- Enhanced error messages for better debugging.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->