### PR TITLE
Fix: Removing handles does not leave an empty string in the database

### DIFF
--- a/components/GitAliasListItem.tsx
+++ b/components/GitAliasListItem.tsx
@@ -3,7 +3,7 @@
 import axios from 'axios';
 import { useState } from 'react';
 import { MdDone, MdEdit } from 'react-icons/md';
-import type { AliasMap, AliasProviderMap, HandleMap } from '../types/AliasMap';
+import type { AliasMap, HandleMap } from '../types/AliasMap';
 import type { RepoProvider } from '../utils/providerAPI';
 import Button from './Button';
 import Chip from './Chip';
@@ -31,11 +31,13 @@ const GitAliasListItem = ({ providerMap, setProviderMap }: { providerMap: AliasM
 		try {
 			const updatedAliasMap: AliasMap = {
 				alias: providerMap.alias,
-				handleMaps: inputHandleMap
+				handleMaps: inputHandleMap.map(handleMap => ({
+					provider: handleMap.provider,
+					handles: handleMap.handles.filter(handle => handle !== '') // Remove empty handles,
+				}))
 			}
 
-			const updatedGitAliasMap: AliasProviderMap = { providerMaps: [updatedAliasMap] };
-			const response = await axios.post('/api/alias', { aliasProviderMap: updatedGitAliasMap }, {
+			const response = await axios.post('/api/alias', { aliasHandleMap: updatedAliasMap }, {
 				headers: {
 					'Content-Type': 'application/json',
 				},

--- a/pages/api/alias.ts
+++ b/pages/api/alias.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from "next";
 import { getGitAliasesWithHandlesFromDB, saveGitAliasMapToDB } from "../../utils/db/aliases";
-import { AliasProviderMap } from "../../types/AliasMap";
+import type { AliasMap, AliasProviderMap } from "../../types/AliasMap";
 import { getServerSession } from "next-auth/next";
 import { authOptions } from "./auth/[...nextauth]";
 
@@ -29,11 +29,12 @@ const aliasHandler = async (req: NextApiRequest, res: NextApiResponse) => {
             res.status(500).json({error: error});
         });
     } else if (method === 'POST') {
-        const aliasProviderMap: AliasProviderMap = body.aliasProviderMap;
-        await saveGitAliasMap(aliasProviderMap)
+        const aliasHandleMap: AliasMap = body.aliasHandleMap;
+        await saveGitAliasMap(aliasHandleMap)
         .then(() => {
             res.status(200).send('Git alias map saved successfully.');
         }).catch((error) => {
+            console.error(`[aliasHandler] Error saving Git alias map: ${error}`);
             res.status(500).json({error: error});
         });
     } else {
@@ -59,12 +60,12 @@ const getGitEmailAliases = async (userId: string, expanded?: boolean): Promise<A
     }
 }
 
-const saveGitAliasMap = async (aliasProviderMap: AliasProviderMap): Promise<void> => {
+const saveGitAliasMap = async (aliasHandleMap: AliasMap): Promise<void> => {
     // Validate that aliasMap is provided
-    if (!aliasProviderMap) {
+    if (!aliasHandleMap) {
         throw new Error("Alias Provider map is required to save Git email aliases.");
     }
-    await saveGitAliasMapToDB(aliasProviderMap);
+    await saveGitAliasMapToDB(aliasHandleMap);
 }
 
 

--- a/utils/db/aliases.ts
+++ b/utils/db/aliases.ts
@@ -99,31 +99,22 @@ export const getGitAliasesWithHandlesFromDB = async (userId: string): Promise<Al
     return aliasProvider;
 }
 
-export const saveGitAliasMapToDB = async (aliasProviderMap: AliasProviderMap) => {
-    const values: string[] = [];
-    for (const aliasMap of aliasProviderMap.providerMaps) {
-        const { alias, handleMaps } = aliasMap;
-        let githubHandle = null;
-        let bitbucketHandle = null;
+export const saveGitAliasMapToDB = async (aliasMap: AliasMap) => {
+    const { alias, handleMaps } = aliasMap;
+    let githubHandle = null;
+    let bitbucketHandle = null;
 
-        for (const handleMap of handleMaps) {
-            if (handleMap.provider === 'github' && handleMap.handles.length > 0) {
-                githubHandle = convert(handleMap.handles)
-            } else if (handleMap.provider === 'bitbucket' && handleMap.handles.length > 0) {
-                bitbucketHandle = convert(handleMap.handles)
-            }
+    for (const handleMap of handleMaps) {
+        if (handleMap.provider === 'github' && handleMap.handles.length > 0) {
+            githubHandle = convert(handleMap.handles)
+        } else if (handleMap.provider === 'bitbucket' && handleMap.handles.length > 0) {
+            bitbucketHandle = convert(handleMap.handles)
         }
-
-        values.push(`('${alias}', ${githubHandle}, ${bitbucketHandle})`);
     }
-
-    if (values.length <= 0) {
-        console.info(`[saveGitAliasMapToDB] No new values to insert.`);
-    }
-    const valuesClause = values.join(', ');
+    const aliasesRowValue = `('${alias}', ${githubHandle}, ${bitbucketHandle})`;
     const query = `
         INSERT INTO aliases (git_alias, github, bitbucket)
-        VALUES ${valuesClause}
+        VALUES ${aliasesRowValue}
         ON CONFLICT (git_alias) DO UPDATE SET 
             github = (
                 SELECT ARRAY(SELECT DISTINCT UNNEST(excluded.github))


### PR DESCRIPTION
1. fix: Removing handles does not leave an empty string in the database
2. breaking: /api/alias end point now takes AliasMap type input instead of AliasProviderMap because now the form submission is on a row level instead of a table level.