### PR TITLE
Fix: RepoList is able to handle empty data in `/api/repoList` response

### DIFF
--- a/views/RepoList.tsx
+++ b/views/RepoList.tsx
@@ -16,7 +16,7 @@ const RepoList = () => {
 		// get the list of repositories of the user
 		axios.get<{ repoList: DbRepoSerializable[] }>(`/api/repoList?nonce=${Math.random()}`) // adding query parameter to bypass cache
 			.then((res) => {
-				if (res?.data) setRepoList(res.data.repoList);
+				if (res?.data && typeof res.data === 'object' && res.data.repoList) setRepoList(res.data.repoList);
 			})
 			.catch(err => {
 				console.error("[RepoList] fetching repo list failed", err);

--- a/views/RepoList.tsx
+++ b/views/RepoList.tsx
@@ -14,9 +14,9 @@ const RepoList = () => {
 	useEffect(() => {
 		setLoading(true);
 		// get the list of repositories of the user
-		axios.get<{repoList: DbRepoSerializable[]}>("/api/repoList")
+		axios.get<{ repoList: DbRepoSerializable[] }>(`/api/repoList?nonce=${Math.random()}`) // adding query parameter to bypass cache
 			.then((res) => {
-				setRepoList(res.data.repoList);
+				if (res?.data) setRepoList(res.data.repoList);
 			})
 			.catch(err => {
 				console.error("[RepoList] fetching repo list failed", err);


### PR DESCRIPTION
1. RepoList receives an empty string in the `res.data` field when 204 status code is returned
2. Bypassed cache for the `/api/repoList` API call using the query parameter method. 